### PR TITLE
Show sender (instead of receiver) in hugs_received view.

### DIFF
--- a/config/optional/views.view.hugs_received.yml
+++ b/config/optional/views.view.hugs_received.yml
@@ -123,11 +123,11 @@ display:
           separator: ', '
           field_api_classes: false
           plugin_id: field
-        name:
-          id: name
-          table: users_field_data
-          field: name
-          relationship: field_hug_receiver
+        user_id:
+          id: user_id
+          table: hug_field_data
+          field: user_id
+          relationship: none
           group_type: group
           admin_label: ''
           label: From
@@ -171,11 +171,11 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          click_sort_column: value
-          type: user_name
+          click_sort_column: target_id
+          type: entity_reference_label
           settings:
-            link_to_entity: false
-          group_column: value
+            link: false
+          group_column: target_id
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -185,8 +185,8 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: user
-          entity_field: name
+          entity_type: hug
+          entity_field: user_id
           plugin_id: field
         status:
           id: status


### PR DESCRIPTION
Right now the hug_received view shows the receiver of a hug with the label "From", which is clearly wrong.

While this feature may not be important for replacing the wunder internal hugging system, I think it's a good idea to have this in place and working - and if it's only for development. This optional config can and will be customized anyway within the projects using this module.