### PR TITLE
Module function name refactoring

### DIFF
--- a/src/Plugin/Block/UserHugCountBlock.php
+++ b/src/Plugin/Block/UserHugCountBlock.php
@@ -24,7 +24,7 @@ class UserHugCountBlock extends BlockBase {
     $user = \Drupal::currentUser();
 
     // Fetch the dates for the current hug window.
-    $hug_window = checkHugWindow(time());
+    $hug_window = wunderhugs_check_hug_window(time());
 
     // Fetch maximum allowed hugs.
     $config = \Drupal::config('wunderhugs.adminsettings');

--- a/src/Plugin/Block/UserHugCountBlock.php
+++ b/src/Plugin/Block/UserHugCountBlock.php
@@ -34,7 +34,7 @@ class UserHugCountBlock extends BlockBase {
     if (isset($user) && $user->id() > 0) {
 
       // Fetch no of hugs in this window and work out remainder.
-      $hug_count = fetchHugNo($user->id(), $hug_window['start'], $hug_window['end']);
+      $hug_count = wunderhugs_fetch_hug_count($user->id(), $hug_window['start'], $hug_window['end']);
       $hugs_remaining = $max_hugs - $hug_count;
       $content .= \Drupal::translation()->formatPlural($hugs_remaining, '<span>1 hug left</span>', '<span>@count hugs left</span>');
     }

--- a/src/Plugin/Block/UserHugStatusBlock.php
+++ b/src/Plugin/Block/UserHugStatusBlock.php
@@ -35,13 +35,13 @@ class UserHugStatusBlock extends BlockBase {
       $content .= '<p>' . $link . '</p>';
 
       // Fetch information about this user's current hug window.
-      $hug_count = fetchHugNo($user->id(), $hug_window['start'], $hug_window['end']);
+      $hug_count = wunderhugs_fetch_hug_count($user->id(), $hug_window['start'], $hug_window['end']);
       $content .= \Drupal::translation()->formatPlural($hug_count, '<p>You have sent 1 hug in this window.</p>', '<p>You have sent @count hugs in this window.</p>');
     }
 
     // General hug window information.
     $content .= '<p>' . date('d M', $hug_window['start']) . ' to ' . date('d M', $hug_window['end']) . '</p>';
-    $content .= '<p>Total hugs this window: ' . fetchHugNo(NULL, $hug_window['start'], $hug_window['end']) . '</p>';
+    $content .= '<p>Total hugs this window: ' . wunderhugs_fetch_hug_count(NULL, $hug_window['start'], $hug_window['end']) . '</p>';
 
     // Fetch information about the previous window.
     $config = \Drupal::config('wunderhugs.adminsettings');
@@ -58,10 +58,10 @@ class UserHugStatusBlock extends BlockBase {
     }
     $content .= '<p>Prev window start: ' . date('d-m-Y', $prev_window_start) . '</p>';
     $content .= '<p>Prev window end: ' . date('d-m-Y', $prev_window_end) . '</p>';
-    $content .= '<p>Total hugs previous window: ' . fetchHugNo(NULL, $prev_window_start, $prev_window_end) . '</p>';
+    $content .= '<p>Total hugs previous window: ' . wunderhugs_fetch_hug_count(NULL, $prev_window_start, $prev_window_end) . '</p>';
 
     // Fetch information about all hugs.
-    $content .= '<p>Total hugs: ' . fetchHugNo() . '</p>';
+    $content .= '<p>Total hugs: ' . wunderhugs_fetch_hug_count() . '</p>';
 
     $build['user_hug_status_block']['#markup'] = $content;
     $build['#cache']['max-age'] = 0;

--- a/src/Plugin/Block/UserHugStatusBlock.php
+++ b/src/Plugin/Block/UserHugStatusBlock.php
@@ -26,7 +26,7 @@ class UserHugStatusBlock extends BlockBase {
     $user = \Drupal::currentUser();
 
     // Fetch the dates for the current hug window.
-    $hug_window = checkHugWindow(time());
+    $hug_window = wunderhugs_check_hug_window(time());
 
     // Hide some info if user is not logged in.
     if (isset($user) && $user->id() > 0) {

--- a/src/Plugin/Validation/Constraint/UserHugLimitConstraintValidator.php
+++ b/src/Plugin/Validation/Constraint/UserHugLimitConstraintValidator.php
@@ -20,7 +20,7 @@ class UserHugLimitConstraintValidator extends ConstraintValidator {
       // Check how many hugs this user has made in this window.
       $config = \Drupal::config('wunderhugs.adminsettings');
       $hug_limit = $config->get('maximum_hugs_per_window');
-      $user_hug_no = fetchHugNo($entity->getOwnerId(), $window_dates['start'], $window_dates['end']);
+      $user_hug_no = wunderhugs_fetch_hug_count($entity->getOwnerId(), $window_dates['start'], $window_dates['end']);
       // Run validation.
       if ($user_hug_no >= $hug_limit) {
         $this->context->addViolation($constraint->message, ['%value' => $hug_limit]);

--- a/src/Plugin/Validation/Constraint/UserHugLimitConstraintValidator.php
+++ b/src/Plugin/Validation/Constraint/UserHugLimitConstraintValidator.php
@@ -16,7 +16,7 @@ class UserHugLimitConstraintValidator extends ConstraintValidator {
   public function validate($entity, Constraint $constraint) {
     if (isset($entity)) {
       // Check which window this applies to.
-      $window_dates = checkHugWindow($entity->get('created')->value);
+      $window_dates = wunderhugs_check_hug_window($entity->get('created')->value);
       // Check how many hugs this user has made in this window.
       $config = \Drupal::config('wunderhugs.adminsettings');
       $hug_limit = $config->get('maximum_hugs_per_window');

--- a/wunderhugs.module
+++ b/wunderhugs.module
@@ -68,7 +68,7 @@ function wunderhugs_check_hug_window($date) {
  * @return int
  *   The number of hugs retrieved.
  */
-function fetchHugNo($uid = NULL, $start_date = NULL, $end_date = NULL) {
+function wunderhugs_fetch_hug_count($uid = NULL, $start_date = NULL, $end_date = NULL) {
   if (is_numeric($uid) && empty($start_date) && empty($end_date)) {
     $hugs = \Drupal::entityQuery('hug')
       ->condition('user_id', $uid)

--- a/wunderhugs.module
+++ b/wunderhugs.module
@@ -32,7 +32,7 @@ function wunderhugs_help($route_name, RouteMatchInterface $route_match) {
  * @return array
  *   Contains the start and end dates of a hug window.
  */
-function checkHugWindow($date) {
+function wunderhugs_check_hug_window($date) {
   // Fetch the window settings from config.
   $config = \Drupal::config('wunderhugs.adminsettings');
   $window_range = $config->get('hug_window');


### PR DESCRIPTION
The functions in wunderhugs.module are not sticking to the Drupal naming convention. This fixes it.